### PR TITLE
fix: netlify treat existing pages with trailing slashes as 404

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,6 +26,9 @@
   to = "/:splat"
   status = 301
 
+[build.processing.html]
+  pretty_urls = false
+
 # :: Production context (normal builds)
 [context.production]
   command = "pnpm run check && pnpm run test:run && pnpm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -20,6 +20,12 @@
 [build.environment]
   NPM_FLAGS = "--production"
 
+# :: Handle trailing slash redirects
+[[redirects]]
+  from = "/*/"
+  to = "/:splat"
+  status = 301
+
 # :: Production context (normal builds)
 [context.production]
   command = "pnpm run check && pnpm run test:run && pnpm run build"


### PR DESCRIPTION
## What this adds

- Fixes netlify redirects. It redirects existing pages with trailing slashes and when you reload the page, it throws a 404. This only happens in netlify not on local environment
- Turns off netlify's pretty urls setting

## Game: [Game Name]

## Testing

- [ ] Check the netlify preview
- [ ] Go to an existing page
- [ ] Reload the page 
- [ ] Check if you're still redirected to the same page not in 404

## Screenshots

[If applicable, show off your work!]
